### PR TITLE
feat/export csv to train

### DIFF
--- a/questiongenerator.py
+++ b/questiongenerator.py
@@ -431,20 +431,20 @@ def print_qa(qa_list: List[Mapping[str, str]], show_answers: bool = True) -> Non
             if show_answers:
                 print(f"{space}A: {answer}\n")
 
-def export_qa_csv(qa_list: List[Mapping[str, str]]) -> None:
+def export_qa_csv(qa_list: List[Mapping[str, str]], file_path) -> None:
     """writes the questions and answers into a prompt and response csv.
        currently only supports full sentence answer type"""
-    with open('qa_list.csv', 'w', newline='') as file:
+    with open('{file_path}.csv'.format(file_path), 'w', newline='') as file:
         writer = csv.writer(file)
         fields = ["prompt", "response"]
         writer.writerow(fields) 
         for i in range(len(qa_list)):
             writer.writerow([qa_list[i]['question'], qa_list[i]["answer"]])
 
-def export_train_csv(qa_list: List[Mapping[str, str]], text_file) -> None:
+def export_train_csv(qa_list: List[Mapping[str, str]], text_file, file_path) -> None:
     """writes the questions, answers and context into text csv.
        currently only supports full sentence answer type."""
-    with open('qa_list.csv', 'w', newline='') as file:
+    with open('{file_path}.csv'.format(file_path), 'w', newline='') as file:
         writer = csv.writer(file)
         fields = ["question", "text"]
         writer.writerow(fields) 

--- a/questiongenerator.py
+++ b/questiongenerator.py
@@ -431,10 +431,10 @@ def print_qa(qa_list: List[Mapping[str, str]], show_answers: bool = True) -> Non
             if show_answers:
                 print(f"{space}A: {answer}\n")
 
-def export_qa_csv(qa_list: List[Mapping[str, str]], file_path) -> None:
+def export_qa_csv(qa_list: List[Mapping[str, str]], file_path: str) -> None:
     """writes the questions and answers into a prompt and response csv.
        currently only supports full sentence answer type"""
-    with open('{file_path}.csv'.format(file_path), 'w', newline='') as file:
+    with open('{file_path}'.format(file_path=file_path), 'w', newline='') as file:
         writer = csv.writer(file)
         fields = ["prompt", "response"]
         writer.writerow(fields) 
@@ -444,7 +444,7 @@ def export_qa_csv(qa_list: List[Mapping[str, str]], file_path) -> None:
 def export_train_csv(qa_list: List[Mapping[str, str]], text_file, file_path) -> None:
     """writes the questions, answers and context into text csv.
        currently only supports full sentence answer type."""
-    with open('{file_path}.csv'.format(file_path), 'w', newline='') as file:
+    with open('{file_path}'.format(file_path=file_path), 'w', newline='') as file:
         writer = csv.writer(file)
         fields = ["question", "text"]
         writer.writerow(fields) 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-datasets==1.16.1
+datasets==2.14.6
 en_core_web_sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.7.1/en_core_web_sm-3.7.1.tar.gz
 numpy==1.22.0
 sentencepiece==0.1.96
 spacy==3.7.2
 tokenizers==0.10.3
-torch==1.8.0
+torch==1.11.0
 transformers==4.12.5

--- a/run_qg.py
+++ b/run_qg.py
@@ -16,8 +16,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--show_answers", dest="show_answers", action="store_true", default=True)
     parser.add_argument("--text_file", type=str, required=True)
     parser.add_argument("--use_qa_eval", dest="use_qa_eval", action="store_true", default=True)
-    parser.add_argument("--export_csv", type=bool)
-    parser.add_argument("--export_train_csv", type=bool)
+    parser.add_argument("--export_csv", type=str, default=None)
+    parser.add_argument("--export_train_csv", type=str, default=None)
     return parser.parse_args()
 
 
@@ -33,7 +33,7 @@ if __name__ == "__main__":
         use_evaluator=args.use_qa_eval
     )
     print_qa(qa_list, show_answers=args.show_answers)
-    if args.export_csv:
+    if args.export_csv is not None:
         export_qa_csv(qa_list)
-    if args.export_train_csv:
+    if args.export_train_csv is not None:
         export_train_csv(qa_list, text_file)

--- a/run_qg.py
+++ b/run_qg.py
@@ -34,6 +34,6 @@ if __name__ == "__main__":
     )
     print_qa(qa_list, show_answers=args.show_answers)
     if args.export_csv is not None:
-        export_qa_csv(qa_list)
+        export_qa_csv(qa_list, args.export_csv)
     if args.export_train_csv is not None:
-        export_train_csv(qa_list, text_file)
+        export_train_csv(qa_list, text_file, args.export_train.csv)

--- a/run_qg.py
+++ b/run_qg.py
@@ -36,4 +36,4 @@ if __name__ == "__main__":
     if args.export_csv is not None:
         export_qa_csv(qa_list, args.export_csv)
     if args.export_train_csv is not None:
-        export_train_csv(qa_list, text_file, args.export_train.csv)
+        export_train_csv(qa_list, text_file, args.export_train_csv)

--- a/run_qg.py
+++ b/run_qg.py
@@ -1,6 +1,6 @@
 import argparse
 from questiongenerator import QuestionGenerator
-from questiongenerator import print_qa, export_qa_csv
+from questiongenerator import print_qa, export_qa_csv, export_train_csv
 
 
 def parse_args() -> argparse.Namespace:
@@ -12,11 +12,12 @@ def parse_args() -> argparse.Namespace:
         help="The desired type of answers. Choose from ['all', 'sentences', 'multiple_choice']",
     )
     parser.add_argument("--model_dir", type=str, default=None)
-    parser.add_argument("--num_questions", type=int, default=10)
+    parser.add_argument("--num_questions", type=int, default=25)
     parser.add_argument("--show_answers", dest="show_answers", action="store_true", default=True)
     parser.add_argument("--text_file", type=str, required=True)
     parser.add_argument("--use_qa_eval", dest="use_qa_eval", action="store_true", default=True)
     parser.add_argument("--export_csv", type=bool)
+    parser.add_argument("--export_train_csv", type=bool)
     return parser.parse_args()
 
 
@@ -34,3 +35,5 @@ if __name__ == "__main__":
     print_qa(qa_list, show_answers=args.show_answers)
     if args.export_csv:
         export_qa_csv(qa_list)
+    if args.export_train_csv:
+        export_train_csv(qa_list, text_file)

--- a/training/qg_train.py
+++ b/training/qg_train.py
@@ -9,16 +9,16 @@ from trainer import Trainer
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--dataloader_workers", type=int, default=2)
-    parser.add_argument("--device", type=str, default="cuda")
+    parser.add_argument("--device", type=str, default="cpu")
     parser.add_argument("--epochs", type=int, default=20)
     parser.add_argument("--learning_rate", type=float, default=1e-3)
     parser.add_argument("--max_length", type=int, default=512)
-    parser.add_argument("--qg_model", type=str, default="t5-base")
+    parser.add_argument("--qg_model", type=str, default="../../model/tadmus")
     parser.add_argument("--pad_mask_id", type=int, default=-100)
     parser.add_argument("--pin_memory", dest="pin_memory", action="store_true", default=False)
     parser.add_argument("--save_dir", type=str, default="./t5-base-question-generator")
     parser.add_argument("--train_batch_size", type=int, default=4)
-    parser.add_argument("--valid_batch_size", type=int, default=32)
+    parser.add_argument("--valid_batch_size", type=int, default=25)
     return parser.parse_args()
 
 
@@ -41,7 +41,9 @@ def get_model(checkpoint: str, device: str, tokenizer: T5Tokenizer) -> T5ForCond
 if __name__ == "__main__":
     args = parse_args()
     tokenizer = get_tokenizer(args.qg_model)
-    dataset = datasets.load_dataset("iarfmoose/question_generator")
+    dataset = datasets.load_dataset("csv",  
+                                    data_files={"train": ["/localhost/TADMUS/fm-390-tatics/qa_generator/train2.csv"], 
+                                                "validation": ["/localhost/TADMUS/fm-390-tatics/qa_generator/valid_qa.csv"]})
     train_set = QGDataset(dataset["train"], args.max_length, args.pad_mask_id, tokenizer)
     valid_set = QGDataset(dataset["validation"], args.max_length, args.pad_mask_id, tokenizer)
     model = get_model(args.qg_model, args.device, tokenizer)


### PR DESCRIPTION
- feat: add ability to export to csv

In order to train the question generator model we need to import data that is in <answer> <question> <context> format. For now we 
will just take the input text file as well as the questions and answers generated from a run as the training set.


Test to print out training set

```
python run_qg.py --text_file /localhost/TADMUS/fm-390-tatics/text/chapter_3/89-101 --export_train_csv REPLACE_ME_WITH_THE_FILE_PATH_TO_THE_DATASET
```

To train the model you will need to reference your dataset  like I did on line 44 and run the command below
```
python training/qg_train.py
```